### PR TITLE
Update z-index in middleware and bump django-devbar version to 0.1.2

### DIFF
--- a/src/django_devbar/middleware.py
+++ b/src/django_devbar/middleware.py
@@ -16,7 +16,7 @@ from .conf import (
 
 STYLE_BLOCK = """<style>
 #django-devbar {
-    position: fixed; %s; z-index: 99999;
+    position: fixed; %s; z-index: 999999999;
     font-family: -apple-system, system-ui, sans-serif;
     font-size: 11px; font-weight: 500;
     padding: 4px 8px; border-radius: 4px;

--- a/uv.lock
+++ b/uv.lock
@@ -63,7 +63,7 @@ wheels = [
 
 [[package]]
 name = "django-devbar"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "django", version = "5.2.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
With a different z-index value, the devbar is now visible on top of the default djDebugToolbar

### Old behavior
<img width="324" height="196" alt="Screenshot 2025-12-12 at 10 42 07" src="https://github.com/user-attachments/assets/45a263e0-19b5-47e9-851a-3934874f169f" />


### New behavior
<img width="314" height="201" alt="Screenshot 2025-12-12 at 10 53 42" src="https://github.com/user-attachments/assets/f61b1b8d-eddb-428e-9492-4ac02fe0c11e" />
