### PR TITLE
Fix #29 -- Preserve existing Server-Timing header

### DIFF
--- a/src/django_devbar/middleware.py
+++ b/src/django_devbar/middleware.py
@@ -165,6 +165,9 @@ class DevBarMiddleware:
             f"app;dur={stats['python_time']:.2f}",
             f"total;dur={stats['total_time']:.2f}",
         ]
+        existing = response.get("Server-Timing")
+        if existing:
+            parts.insert(0, existing)
         response["Server-Timing"] = ", ".join(parts)
 
     def _can_inject(self, response):

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -226,6 +226,34 @@ class TestMiddleware:
         assert "app;dur=" in header
         assert "total;dur=" in header
 
+    def test_server_timing_header_preserves_existing_metrics(self, rf, monkeypatch):
+        monkeypatch.setattr(
+            tracker,
+            "get_stats",
+            lambda: {
+                "count": 3,
+                "duration": 12.5,
+                "duplicate_queries": [],
+            },
+        )
+
+        def get_response(request):
+            response = HttpResponse(
+                "<html><body>Test</body></html>", content_type="text/html"
+            )
+            response["Server-Timing"] = "cache;desc=hit;dur=1.23"
+            return response
+
+        middleware = DevBarMiddleware(get_response)
+        request = rf.get("/")
+        response = middleware(request)
+
+        header = response["Server-Timing"]
+        assert header.startswith("cache;desc=hit;dur=1.23, ")
+        assert "db;dur=12.50" in header
+        assert "app;dur=" in header
+        assert "total;dur=" in header
+
     def test_devtools_data_header_truncated_by_max_bytes(
         self, rf, monkeypatch, settings
     ):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Server-Timing response header handling to preserve existing timing metrics instead of overwriting them. Timing information from multiple sources is now properly combined.

* **Tests**
  * Added test coverage for Server-Timing header preservation and metric aggregation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->