### PR TITLE
[Ext] Fix DevTools reset on same-url navigation

### DIFF
--- a/browser-extension/package.json
+++ b/browser-extension/package.json
@@ -8,6 +8,7 @@
     "build:chrome": "node scripts/build.mjs chrome",
     "build:firefox": "node scripts/build.mjs firefox",
     "build:dev": "node scripts/build.mjs --dev",
+    "test": "node --test tests/*.test.js",
     "generate-icons": "node scripts/generate-icons.mjs",
     "zip:chrome": "cd dist/chrome && zip -r ../../django-devbar-chrome.zip .",
     "zip:firefox": "cd dist/firefox && zip -r ../../django-devbar-firefox.zip ."

--- a/browser-extension/src/navigation.js
+++ b/browser-extension/src/navigation.js
@@ -13,8 +13,9 @@ export function isSameNavigationUrl(previousUrl, nextUrl) {
 }
 
 export function getRequestHeader(request, name) {
+  const lowerName = name.toLowerCase();
   return request.request.headers
-    ?.find(h => h.name.toLowerCase() === name)
+    ?.find(h => h.name.toLowerCase() === lowerName)
     ?.value.toLowerCase();
 }
 

--- a/browser-extension/src/navigation.js
+++ b/browser-extension/src/navigation.js
@@ -1,0 +1,38 @@
+export function isSameNavigationUrl(previousUrl, nextUrl) {
+  if (!previousUrl || !nextUrl) return false;
+
+  try {
+    const previous = new URL(previousUrl);
+    const next = new URL(nextUrl, previous);
+    previous.hash = '';
+    next.hash = '';
+    return previous.href === next.href;
+  } catch (e) {
+    return previousUrl.split('#')[0] === nextUrl.split('#')[0];
+  }
+}
+
+export function getRequestHeader(request, name) {
+  return request.request.headers
+    ?.find(h => h.name.toLowerCase() === name)
+    ?.value.toLowerCase();
+}
+
+export function isNavigationDocumentRequest(request) {
+  return request._resourceType === 'document'
+    || getRequestHeader(request, 'sec-fetch-dest') === 'document';
+}
+
+export function shouldResetForMainDocumentRequest({
+  request,
+  pageUrl,
+  pendingNavigationUrl,
+  hasCapturedRequests,
+  skipRender = false,
+}) {
+  if (skipRender || !hasCapturedRequests) return false;
+  if (!pageUrl || !request?.request?.url) return false;
+  if (!isSameNavigationUrl(request.request.url, pageUrl)) return false;
+  if (!isNavigationDocumentRequest(request)) return false;
+  return !pendingNavigationUrl || isSameNavigationUrl(request.request.url, pendingNavigationUrl);
+}

--- a/browser-extension/src/panel.js
+++ b/browser-extension/src/panel.js
@@ -75,7 +75,11 @@ evalInspectedWindow('location.href', (result, error) => {
 });
 
 extensionApi.devtools.network.onNavigated.addListener((url) => {
+  const previousPageUrl = pageUrl;
   pageUrl = url;
+
+  if (isSameNavigationUrl(previousPageUrl, url)) return;
+
   requestHistory = [];
   currentRequest = null;
   renderUI();
@@ -236,6 +240,20 @@ function getPathFromUrl(url) {
     return parsed.pathname + parsed.search;
   } catch (e) {
     return url;
+  }
+}
+
+function isSameNavigationUrl(previousUrl, nextUrl) {
+  if (!previousUrl || !nextUrl) return false;
+
+  try {
+    const previous = new URL(previousUrl);
+    const next = new URL(nextUrl, previous);
+    previous.hash = '';
+    next.hash = '';
+    return previous.href === next.href;
+  } catch (e) {
+    return previousUrl.split('#')[0] === nextUrl.split('#')[0];
   }
 }
 

--- a/browser-extension/src/panel.js
+++ b/browser-extension/src/panel.js
@@ -61,6 +61,7 @@ let currentRequest = null;
 let pageUrl = null;
 let pageUrlReady = false;
 let pendingHarLog = null;
+let pendingNavigationUrl = null;
 const copyResetTimers = new WeakMap();
 
 evalInspectedWindow('location.href', (result, error) => {
@@ -75,14 +76,8 @@ evalInspectedWindow('location.href', (result, error) => {
 });
 
 extensionApi.devtools.network.onNavigated.addListener((url) => {
-  const previousPageUrl = pageUrl;
   pageUrl = url;
-
-  if (isSameNavigationUrl(previousPageUrl, url)) return;
-
-  requestHistory = [];
-  currentRequest = null;
-  renderUI();
+  pendingNavigationUrl = url;
 });
 
 const formatMs = (value) => value?.toFixed(0) ?? '0';
@@ -279,10 +274,21 @@ function parseDevBarHeaders(headers) {
   return null;
 }
 
+function getRequestHeader(request, name) {
+  return request.request.headers
+    ?.find(h => h.name.toLowerCase() === name)
+    ?.value.toLowerCase();
+}
+
 function isDocumentRequest(request) {
   if (request._resourceType === 'document') return true;
   const contentType = request.response.headers.find(h => h.name.toLowerCase() === 'content-type');
   return contentType?.value.includes('text/html') ?? false;
+}
+
+function isNavigationDocumentRequest(request) {
+  return request._resourceType === 'document'
+    || getRequestHeader(request, 'sec-fetch-dest') === 'document';
 }
 
 function isMainPageRequest(url) {
@@ -291,12 +297,37 @@ function isMainPageRequest(url) {
   return normalize(url) === normalize(pageUrl);
 }
 
-function processRequest(request, options = {}) {
-  const data = parseDevBarHeaders(request.response.headers);
-  if (!data) return;
+function isCurrentPageNavigationRequest(url) {
+  return pageUrl ? isSameNavigationUrl(url, pageUrl) : false;
+}
 
+function resetCapturedRequests() {
+  requestHistory = [];
+  currentRequest = null;
+}
+
+function shouldResetForMainDocumentRequest(request, options) {
+  if (options.skipRender || (!currentRequest && !requestHistory.length)) return false;
+  if (!isCurrentPageNavigationRequest(request.request.url)) return false;
+  if (!isNavigationDocumentRequest(request)) return false;
+  return !pendingNavigationUrl || isSameNavigationUrl(request.request.url, pendingNavigationUrl);
+}
+
+function processRequest(request, options = {}) {
   const isDocument = isDocumentRequest(request);
   const isMainPage = isMainPageRequest(request.request.url);
+  const shouldReset = shouldResetForMainDocumentRequest(request, options);
+
+  if (shouldReset) {
+    resetCapturedRequests();
+    pendingNavigationUrl = null;
+  }
+
+  const data = parseDevBarHeaders(request.response.headers);
+  if (!data) {
+    if (shouldReset) renderUI();
+    return;
+  }
 
   const requestData = {
     url: request.request.url,

--- a/browser-extension/src/panel.js
+++ b/browser-extension/src/panel.js
@@ -1,3 +1,5 @@
+import { shouldResetForMainDocumentRequest } from './navigation.js';
+
 const extensionApi = globalThis.browser ?? globalThis.chrome;
 const usesPromiseApi = Boolean(globalThis.browser?.devtools || globalThis.browser?.storage);
 const MAX_HISTORY = 50;
@@ -238,20 +240,6 @@ function getPathFromUrl(url) {
   }
 }
 
-function isSameNavigationUrl(previousUrl, nextUrl) {
-  if (!previousUrl || !nextUrl) return false;
-
-  try {
-    const previous = new URL(previousUrl);
-    const next = new URL(nextUrl, previous);
-    previous.hash = '';
-    next.hash = '';
-    return previous.href === next.href;
-  } catch (e) {
-    return previousUrl.split('#')[0] === nextUrl.split('#')[0];
-  }
-}
-
 function parseDevBarHeaders(headers) {
   const devbarHeaders = {};
   for (const { name, value } of headers) {
@@ -274,21 +262,10 @@ function parseDevBarHeaders(headers) {
   return null;
 }
 
-function getRequestHeader(request, name) {
-  return request.request.headers
-    ?.find(h => h.name.toLowerCase() === name)
-    ?.value.toLowerCase();
-}
-
 function isDocumentRequest(request) {
   if (request._resourceType === 'document') return true;
   const contentType = request.response.headers.find(h => h.name.toLowerCase() === 'content-type');
   return contentType?.value.includes('text/html') ?? false;
-}
-
-function isNavigationDocumentRequest(request) {
-  return request._resourceType === 'document'
-    || getRequestHeader(request, 'sec-fetch-dest') === 'document';
 }
 
 function isMainPageRequest(url) {
@@ -297,26 +274,21 @@ function isMainPageRequest(url) {
   return normalize(url) === normalize(pageUrl);
 }
 
-function isCurrentPageNavigationRequest(url) {
-  return pageUrl ? isSameNavigationUrl(url, pageUrl) : false;
-}
-
 function resetCapturedRequests() {
   requestHistory = [];
   currentRequest = null;
 }
 
-function shouldResetForMainDocumentRequest(request, options) {
-  if (options.skipRender || (!currentRequest && !requestHistory.length)) return false;
-  if (!isCurrentPageNavigationRequest(request.request.url)) return false;
-  if (!isNavigationDocumentRequest(request)) return false;
-  return !pendingNavigationUrl || isSameNavigationUrl(request.request.url, pendingNavigationUrl);
-}
-
 function processRequest(request, options = {}) {
   const isDocument = isDocumentRequest(request);
   const isMainPage = isMainPageRequest(request.request.url);
-  const shouldReset = shouldResetForMainDocumentRequest(request, options);
+  const shouldReset = shouldResetForMainDocumentRequest({
+    request,
+    pageUrl,
+    pendingNavigationUrl,
+    hasCapturedRequests: Boolean(currentRequest || requestHistory.length),
+    skipRender: options.skipRender,
+  });
 
   if (shouldReset) {
     resetCapturedRequests();

--- a/browser-extension/tests/navigation.test.js
+++ b/browser-extension/tests/navigation.test.js
@@ -1,0 +1,119 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  isSameNavigationUrl,
+  shouldResetForMainDocumentRequest,
+} from '../src/navigation.js';
+
+function request(url, { resourceType, headers = [] } = {}) {
+  return {
+    _resourceType: resourceType,
+    request: { url, headers },
+  };
+}
+
+function shouldReset(overrides = {}) {
+  return shouldResetForMainDocumentRequest({
+    request: request('https://example.com/page', { resourceType: 'document' }),
+    pageUrl: 'https://example.com/page',
+    pendingNavigationUrl: null,
+    hasCapturedRequests: true,
+    skipRender: false,
+    ...overrides,
+  });
+}
+
+describe('isSameNavigationUrl', () => {
+  it('ignores hash changes', () => {
+    assert.equal(
+      isSameNavigationUrl('https://example.com/page#one', 'https://example.com/page#two'),
+      true,
+    );
+  });
+
+  it('keeps query string changes distinct', () => {
+    assert.equal(
+      isSameNavigationUrl('https://example.com/page?one=1', 'https://example.com/page?one=2'),
+      false,
+    );
+  });
+});
+
+describe('shouldResetForMainDocumentRequest', () => {
+  it('resets for a real same-URL document reload', () => {
+    assert.equal(shouldReset(), true);
+  });
+
+  it('does not reset on History API navigation alone or following XHRs', () => {
+    assert.equal(
+      shouldReset({
+        request: request('https://example.com/page', { headers: [{ name: 'sec-fetch-mode', value: 'cors' }] }),
+        pendingNavigationUrl: 'https://example.com/page',
+      }),
+      false,
+    );
+  });
+
+  it('does not lose a pending same-URL reload when an XHR finishes first', () => {
+    const pendingNavigationUrl = 'https://example.com/page';
+
+    assert.equal(
+      shouldReset({
+        request: request('https://example.com/page', { headers: [{ name: 'sec-fetch-mode', value: 'cors' }] }),
+        pendingNavigationUrl,
+      }),
+      false,
+    );
+    assert.equal(
+      shouldReset({
+        request: request('https://example.com/page', { resourceType: 'document' }),
+        pendingNavigationUrl,
+      }),
+      true,
+    );
+  });
+
+  it('does not reset for same-page HTML XHRs without document markers', () => {
+    assert.equal(
+      shouldReset({
+        request: request('https://example.com/page'),
+        pendingNavigationUrl: 'https://example.com/page',
+      }),
+      false,
+    );
+  });
+
+  it('accepts Sec-Fetch-Dest document as a document marker', () => {
+    assert.equal(
+      shouldReset({
+        request: request('https://example.com/page', {
+          headers: [{ name: 'Sec-Fetch-Dest', value: 'document' }],
+        }),
+      }),
+      true,
+    );
+  });
+
+  it('does not reset for pending navigation URL mismatches', () => {
+    assert.equal(
+      shouldReset({
+        request: request('https://example.com/page', { resourceType: 'document' }),
+        pageUrl: 'https://example.com/page',
+        pendingNavigationUrl: 'https://example.com/other',
+      }),
+      false,
+    );
+  });
+
+  it('matches reload requests when only the hash differs', () => {
+    assert.equal(
+      shouldReset({
+        request: request('https://example.com/page', { resourceType: 'document' }),
+        pageUrl: 'https://example.com/page#section',
+        pendingNavigationUrl: 'https://example.com/page#section',
+      }),
+      true,
+    );
+  });
+});

--- a/browser-extension/tests/navigation.test.js
+++ b/browser-extension/tests/navigation.test.js
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
 import {
+  getRequestHeader,
   isSameNavigationUrl,
   shouldResetForMainDocumentRequest,
 } from '../src/navigation.js';
@@ -36,6 +37,23 @@ describe('isSameNavigationUrl', () => {
     assert.equal(
       isSameNavigationUrl('https://example.com/page?one=1', 'https://example.com/page?one=2'),
       false,
+    );
+  });
+});
+
+describe('getRequestHeader', () => {
+  it('matches header names case-insensitively', () => {
+    assert.equal(
+      getRequestHeader(request('https://example.com/page', {
+        headers: [{ name: 'Sec-Fetch-Dest', value: 'Document' }],
+      }), 'sec-fetch-dest'),
+      'document',
+    );
+    assert.equal(
+      getRequestHeader(request('https://example.com/page', {
+        headers: [{ name: 'sec-fetch-dest', value: 'Document' }],
+      }), 'Sec-Fetch-Dest'),
+      'document',
     );
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request history tracking during navigations by deferring reset until a main-document navigation is confirmed.
  * Enhanced URL comparison to treat hash-only changes as the same navigation.
  * More reliable identification of main-document requests (including `Sec-Fetch-Dest: document`) to prevent incorrect history clearing and improve deduplication.
* **Tests**
  * Added automated coverage for navigation and reset decision logic to prevent regressions.
* **Chores**
  * Added a dedicated test script for running the extension’s Node-based test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->